### PR TITLE
Add error reasons to unit tests (#34)

### DIFF
--- a/test/pCToken.ts
+++ b/test/pCToken.ts
@@ -69,7 +69,9 @@ describe("PCToken", function () {
     it("Burning more than an address's balance should fail", async () => {
       const mintAmount = constants.WeiPerEther;
       await pcToken.mint(account, mintAmount);
-      await expect(pcToken.burn(account, constants.WeiPerEther.add(1))).to.be.reverted;
+      await expect(pcToken.burn(account, constants.WeiPerEther.add(1))).to.be.revertedWith(
+        "ERR_INSUFFICIENT_BAL"
+      );
     });
   });
   describe("balanceOf", async () => {
@@ -87,7 +89,9 @@ describe("PCToken", function () {
   describe("transfer", async () => {
     it("Should fail when the sender does not have enought balance", async () => {
       await pcToken.mint(account, constants.WeiPerEther);
-      await expect(pcToken.transfer(account2, constants.WeiPerEther.add(1))).to.be.reverted;
+      await expect(pcToken.transfer(account2, constants.WeiPerEther.add(1))).to.be.revertedWith(
+        "ERR_INSUFFICIENT_BAL"
+      );
     });
     it("Sending the entire balance should work", async () => {
       await pcToken.mint(account, constants.WeiPerEther);
@@ -157,7 +161,9 @@ describe("PCToken", function () {
     });
     it("Increasing approval beyond max uint256 should fail", async () => {
       await pcToken.increaseApproval(account2, constants.MaxUint256);
-      await expect(pcToken.increaseApproval(account2, constants.WeiPerEther)).to.be.reverted;
+      await expect(pcToken.increaseApproval(account2, constants.WeiPerEther)).to.be.revertedWith(
+        "ERR_ADD_OVERFLOW"
+      );
     });
   });
   describe("decreaseApproval", async () => {
@@ -212,13 +218,16 @@ describe("PCToken", function () {
     it("Should fail when not enough allowance is set", async () => {
       await pcToken.approve(account2, constants.WeiPerEther.sub(1));
       pcToken = pcToken.connect(signers[1]);
-      await expect(pcToken.transferFrom(account, account2, constants.WeiPerEther)).to.be.reverted;
+      await expect(
+        pcToken.transferFrom(account, account2, constants.WeiPerEther)
+      ).to.be.revertedWith("ERR_PCTOKEN_BAD_CALLER");
     });
     it("Should fail when sender does not have enough balance", async () => {
       await pcToken.approve(account2, constants.WeiPerEther.add(1));
       pcToken = pcToken.connect(signers[1]);
-      await expect(pcToken.transferFrom(account, account2, constants.WeiPerEther.add(1))).to.be
-        .reverted;
+      await expect(
+        pcToken.transferFrom(account, account2, constants.WeiPerEther.add(1))
+      ).to.be.revertedWith("ERR_INSUFFICIENT_BAL");
     });
     it("Should not change approval amount when it was set to max uint256", async () => {
       await pcToken.approve(account2, constants.MaxUint256);

--- a/test/pCappedSmartPool.ts
+++ b/test/pCappedSmartPool.ts
@@ -80,7 +80,9 @@ describe("PCappedSmartPool", function () {
 
   it("Setting the cap from a non controller address should fail", async () => {
     await smartpool.setController(await signers[1].getAddress());
-    await expect(smartpool.setCap(100)).to.be.reverted;
+    await expect(smartpool.setCap(100)).to.be.revertedWith(
+      "PBasicSmartPool.onlyController: not controller"
+    );
   });
 
   it("JoinPool with less than the cap should work", async () => {
@@ -96,6 +98,8 @@ describe("PCappedSmartPool", function () {
   it("JoinPool with more than the cap should fail", async () => {
     const cap = constants.WeiPerEther.mul(100);
     await smartpool.setCap(cap);
-    await expect(smartpool.joinPool(cap.add(1))).to.be.reverted;
+    await expect(smartpool.joinPool(cap.add(1))).to.be.revertedWith(
+      "PCappedSmartPool.withinCap: Cap limit reached"
+    );
   });
 });

--- a/test/reentryProtection.ts
+++ b/test/reentryProtection.ts
@@ -28,6 +28,8 @@ describe("ReentryProtection", function () {
   });
 
   it("Should prevent reentry", async () => {
-    await expect(testContract.test()).to.be.reverted;
+    await expect(testContract.test()).to.be.revertedWith(
+      "ReentryProtection.noReentry: reentry detected"
+    );
   });
 });


### PR DESCRIPTION
##### Description
Change tests using `.to.be.reverted` to `to.be.revertedWith` to check if the error message is the one we expect.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Test coverage hasn't decreased

##### Testing


##### Refers/Fixes
#34 

