### PR TITLE
Fixing #58 and #59

### DIFF
--- a/contracts/libraries/LibAddRemoveToken.sol
+++ b/contracts/libraries/LibAddRemoveToken.sol
@@ -31,6 +31,9 @@ library LibAddRemoveToken {
       "ERR_ERC20_FALSE"
     );
 
+    // Cancel potential weight adjustment process.
+    ws.startBlock = 0;
+
     // Approves bPool to pull from this controller
     IERC20(ws.newToken.addr).safeApprove(address(s.bPool), uint256(-1));
     s.bPool.bind(ws.newToken.addr, ws.newToken.balance, ws.newToken.denorm);

--- a/contracts/libraries/LibAddRemoveToken.sol
+++ b/contracts/libraries/LibAddRemoveToken.sol
@@ -61,6 +61,7 @@ library LibAddRemoveToken {
   }
 
   function removeToken(address _token) external {
+    P2Storage.StorageStruct storage ws = P2Storage.load();
     PBStorage.StorageStruct storage s = PBStorage.load();
 
     uint256 totalSupply = PCStorage.load().totalSupply;
@@ -73,6 +74,9 @@ library LibAddRemoveToken {
     // this is what will be unbound from the pool
     // Have to get it before unbinding
     uint256 balance = s.bPool.getBalance(_token);
+
+    // Cancel potential weight adjustment process.
+    ws.startBlock = 0;
 
     // Unbind and get the tokens out of balancer pool
     s.bPool.unbind(_token);

--- a/contracts/libraries/LibWeights.sol
+++ b/contracts/libraries/LibWeights.sol
@@ -12,6 +12,7 @@ library LibWeights {
 
   function updateWeight(address _token, uint256 _newWeight) external {
     PBStorage.StorageStruct storage s = PBStorage.load();
+    P2Storage.StorageStruct storage ws = P2Storage.load();
 
     require(_newWeight >= constants.MIN_WEIGHT, "ERR_MIN_WEIGHT");
     require(_newWeight <= constants.MAX_WEIGHT, "ERR_MAX_WEIGHT");
@@ -45,6 +46,9 @@ library LibWeights {
       // Now with the tokens this contract can send them to msg.sender
       require(IERC20(_token).transfer(msg.sender, deltaBalance), "ERR_ERC20_FALSE");
 
+      // Cancel potential weight adjustment process.
+      ws.startBlock = 0;
+
       LibPoolToken._burn(msg.sender, poolShares);
     } else {
       // This means the controller will deposit tokens to keep the price.
@@ -65,6 +69,9 @@ library LibWeights {
       );
       // Now with the tokens this contract can bind them to the pool it controls
       s.bPool.rebind(_token, currentBalance.badd(deltaBalance), _newWeight);
+
+      // Cancel potential weight adjustment process.
+      ws.startBlock = 0;
 
       LibPoolToken._mint(msg.sender, poolShares);
     }

--- a/contracts/libraries/LibWeights.sol
+++ b/contracts/libraries/LibWeights.sol
@@ -114,6 +114,7 @@ library LibWeights {
     PBStorage.StorageStruct storage s = PBStorage.load();
     P2Storage.StorageStruct storage ws = P2Storage.load();
 
+    require(ws.startBlock != 0, "ERR_WEIGHT_ADJUSTMENT_FINISHED");
     require(block.number >= ws.startBlock, "ERR_CANT_POKE_YET");
 
     // This allows for pokes after endBlock that get weights to endWeights
@@ -141,6 +142,14 @@ library LibWeights {
         );
       }
       s.bPool.rebind(tokens[i], s.bPool.getBalance(tokens[i]), newWeight);
+    }
+
+    if(minBetweenEndBlockAndThisBlock == ws.endBlock) {
+      // All the weights are adjusted, adjustment finished.
+
+      // save gas option: set this to max number instead of 0
+      // And be able to remove ERR_WEIGHT_ADJUSTMENT_FINISHED check
+      ws.startBlock = 0;
     }
   }
 }

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -368,6 +368,16 @@ describe("Advanced Pool Functionality", function () {
       expect(weightsAfter).to.eql(weigthsFixturePokeWeightsUp, "Weight increase incorrect");
     });
 
+    it("Poking the weight twice after the end block should fail", async () => {
+      await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+      await smartpool.pokeWeights();
+      await mine_blocks(5);
+      await smartpool.pokeWeights();
+      await mine_blocks(200);
+      await smartpool.pokeWeights();
+      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+    });
+
     describe("Adding tokens", async () => {
       let newToken: MockToken;
 

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -397,6 +397,9 @@ describe("Advanced Pool Functionality", function () {
         // remove a token
         await smartpool.removeToken(tokens[tokens.length - 2].address);
         await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
       });
 
       it("Weight update should cancel when adding token", async () => {
@@ -412,6 +415,9 @@ describe("Advanced Pool Functionality", function () {
 
         // throws 'VM Exception while processing transaction: invalid opcode' @ f4aab193
         await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
       });
 
       it("Weight update should cancel when calling bind", async () => {
@@ -426,6 +432,9 @@ describe("Advanced Pool Functionality", function () {
         await smartpool.bind(token.address, constants.WeiPerEther, constants.WeiPerEther);
 
         await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
       });
 
       it("Weight update should cancel when calling unbind", async () => {
@@ -435,6 +444,9 @@ describe("Advanced Pool Functionality", function () {
         // unbinding a token
         smartpool.unbind(tokens[0].address);
         await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
       });
 
       it("Weight update should cancel when calling rebind", async () => {
@@ -448,6 +460,9 @@ describe("Advanced Pool Functionality", function () {
           constants.WeiPerEther.mul(2)
         );
         await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
       });
 
       it("commitAddToken should work", async () => {

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -389,6 +389,26 @@ describe("Advanced Pool Functionality", function () {
       await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
     })
 
+    it("Weight update should cancel when adding token", async () => {
+      // verify there is no current adjustment going on
+      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+      // remove token
+      await smartpool.removeToken(tokens[tokens.length - 1].address);
+      // start adjustment
+      await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+      await smartpool.pokeWeights();
+      // add new token
+      const newToken = tokens[tokens.length - 1];
+      const balance = constants.WeiPerEther.mul(100);
+      const weight = constants.WeiPerEther.mul(2);
+      await smartpool.commitAddToken(newToken.address, balance, weight);
+      await smartpool.pokeWeights();
+      await smartpool.applyAddToken();
+
+      // throws 'VM Exception while processing transaction: invalid opcode' @ f4aab193
+      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+    })
+
     describe("Adding tokens", async () => {
       let newToken: MockToken;
 

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -378,6 +378,17 @@ describe("Advanced Pool Functionality", function () {
       await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
     });
 
+    it("Weight update should cancel when removing token", async () => {
+      // verify there is no current adjustment going on
+      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+      // start adjustment
+      await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+      await smartpool.pokeWeights();
+      // remove a token
+      await smartpool.removeToken(tokens[tokens.length - 1].address);
+      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+    })
+
     describe("Adding tokens", async () => {
       let newToken: MockToken;
 

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -465,6 +465,32 @@ describe("Advanced Pool Functionality", function () {
         await smartpool.pokeWeights();
       });
 
+      it("Weight update should cancel when calling updateWeight (down)", async () => {
+        // start adjustment
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+        // updating weight down
+        const weightsBefore = await smartpool.getDenormalizedWeights();
+        await smartpool.updateWeight(tokens[0].address, weightsBefore[0].div(2))
+        await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+      });
+
+      it("Weight update should cancel when calling updateWeight (up)", async () => {
+        // start adjustment
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+        // updating weight up
+        const weightsBefore = await smartpool.getDenormalizedWeights();
+        await smartpool.updateWeight(tokens[0].address, weightsBefore[0].mul(2))
+        await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // weight adjustment should still work
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+      });
+
       it("commitAddToken should work", async () => {
         const balance = constants.WeiPerEther.mul(100);
         const weight = constants.WeiPerEther.mul(2);

--- a/test/advancedPoolFunctionality.ts
+++ b/test/advancedPoolFunctionality.ts
@@ -378,37 +378,6 @@ describe("Advanced Pool Functionality", function () {
       await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
     });
 
-    it("Weight update should cancel when removing token", async () => {
-      // verify there is no current adjustment going on
-      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
-      // start adjustment
-      await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
-      await smartpool.pokeWeights();
-      // remove a token
-      await smartpool.removeToken(tokens[tokens.length - 1].address);
-      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
-    })
-
-    it("Weight update should cancel when adding token", async () => {
-      // verify there is no current adjustment going on
-      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
-      // remove token
-      await smartpool.removeToken(tokens[tokens.length - 1].address);
-      // start adjustment
-      await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
-      await smartpool.pokeWeights();
-      // add new token
-      const newToken = tokens[tokens.length - 1];
-      const balance = constants.WeiPerEther.mul(100);
-      const weight = constants.WeiPerEther.mul(2);
-      await smartpool.commitAddToken(newToken.address, balance, weight);
-      await smartpool.pokeWeights();
-      await smartpool.applyAddToken();
-
-      // throws 'VM Exception while processing transaction: invalid opcode' @ f4aab193
-      await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
-    })
-
     describe("Adding tokens", async () => {
       let newToken: MockToken;
 
@@ -416,6 +385,32 @@ describe("Advanced Pool Functionality", function () {
         // Pop off the last token for testing
         await smartpool.removeToken(tokens[tokens.length - 1].address);
         newToken = tokens[tokens.length - 1];
+      });
+
+      it("Weight update should cancel when removing token", async () => {
+        // verify there is no current adjustment going on
+        await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+        // start adjustment
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+        // remove a token
+        await smartpool.removeToken(tokens[tokens.length - 2].address);
+        await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
+      });
+
+      it("Weight update should cancel when adding token", async () => {
+        // start adjustment
+        await smartpool.updateWeightsGradually(weigthsFixturePokeWeightsUp, startBlock, endBlock);
+        await smartpool.pokeWeights();
+        // add new token
+        const balance = constants.WeiPerEther.mul(100);
+        const weight = constants.WeiPerEther.mul(2);
+        await smartpool.commitAddToken(newToken.address, balance, weight);
+        await smartpool.pokeWeights();
+        await smartpool.applyAddToken();
+
+        // throws 'VM Exception while processing transaction: invalid opcode' @ f4aab193
+        await expect(smartpool.pokeWeights()).to.be.revertedWith("ERR_WEIGHT_ADJUSTMENT_FINISHED");
       });
 
       it("commitAddToken should work", async () => {

--- a/test/basicPoolFunctionality.ts
+++ b/test/basicPoolFunctionality.ts
@@ -668,6 +668,25 @@ describe("Basic Pool Functionality", function () {
     });
   });
 
+  describe("lockBPoolSwap modifier", async () => {
+    it("If swap disabled, keep disabled", async () => {
+      await expect (await smartpool.isPublicSwap()).is.eq(false);
+      await smartpool.joinPool(constants.WeiPerEther);
+      await expect (await pool.isPublicSwap()).is.eq(false);
+    });
+    it("If swap enabled, keep enabled", async () => {
+      await smartpool.setPublicSwap(true);
+      await expect (await smartpool.isPublicSwap()).is.eq(true);
+      // would be nice of we can verify the following calls
+      //    setPublicSwap(false)
+      //    setPublicSwap(true)
+      // Is there a mocking library that allows this?
+      // Or test by require(isPublicSwap == false) in a function
+      await smartpool.joinPool(constants.WeiPerEther);
+      await expect (await smartpool.isPublicSwap()).is.eq(true);
+    });
+  });
+
   describe("Utility Functions", async () => {
     describe("getDenormalizedWeight(address _token)", async () => {
       it("Should return denormalized weight of underlying token in bPool", async () => {


### PR DESCRIPTION
##### Description
Fix two issues with extras, including potential bug.

##### Refers/Fixes
Fixing #58 in the first 2 commits

Fixing #59 in the last 3 commits
`9fc36f40` is making sure `pokeWeights` can not be called after the weight adjustment has finished. 
`8f8009e` is making sure current weight adjustments are canceled after deleting a token 
`316708` is making sure current weight adjustments are canceled after adding a token 

