### PR TITLE
Upgrade prettier-solidity

### DIFF
--- a/contracts/libraries/LibAddRemoveToken.sol
+++ b/contracts/libraries/LibAddRemoveToken.sol
@@ -20,9 +20,8 @@ library LibAddRemoveToken {
 
     uint256 totalSupply = PCStorage.load().totalSupply;
 
-    uint256 poolShares = totalSupply.bmul(ws.newToken.denorm).bdiv(
-      s.bPool.getTotalDenormalizedWeight()
-    );
+    uint256 poolShares =
+      totalSupply.bmul(ws.newToken.denorm).bdiv(s.bPool.getTotalDenormalizedWeight());
 
     ws.newToken.isCommitted = false;
 
@@ -70,9 +69,10 @@ library LibAddRemoveToken {
     uint256 totalSupply = PCStorage.load().totalSupply;
 
     // poolShares = totalSupply * tokenWeight / totalWeight
-    uint256 poolShares = totalSupply.bmul(s.bPool.getDenormalizedWeight(_token)).bdiv(
-      s.bPool.getTotalDenormalizedWeight()
-    );
+    uint256 poolShares =
+      totalSupply.bmul(s.bPool.getDenormalizedWeight(_token)).bdiv(
+        s.bPool.getTotalDenormalizedWeight()
+      );
 
     // this is what will be unbound from the pool
     // Have to get it before unbinding

--- a/contracts/libraries/LibPoolEntryExit.sol
+++ b/contracts/libraries/LibPoolEntryExit.sol
@@ -19,7 +19,7 @@ library LibPoolEntryExit {
 
   modifier lockBPoolSwap() {
     IBPool bPool = PBStorage.load().bPool;
-    if(bPool.isPublicSwap()) {
+    if (bPool.isPublicSwap()) {
       // If public swap is enabled turn it of, execute function and turn it off again
       bPool.setPublicSwap(false);
       _;
@@ -221,7 +221,7 @@ library LibPoolEntryExit {
     address _token,
     uint256 _amountIn,
     uint256 _minPoolAmountOut
-  ) external lockBPoolSwap returns (uint256 poolAmountOut)  {
+  ) external lockBPoolSwap returns (uint256 poolAmountOut) {
     IBPool bPool = PBStorage.load().bPool;
     LibFees.chargeOutstandingAnnualFee();
     require(bPool.isBound(_token), "LibPoolEntryExit.joinswapExternAmountIn: Token Not Bound");

--- a/contracts/libraries/LibPoolMath.sol
+++ b/contracts/libraries/LibPoolMath.sol
@@ -270,9 +270,8 @@ library LibPoolMath {
   {
     tokens = PBStorage.load().bPool.getCurrentTokens();
     amounts = new uint256[](tokens.length);
-    uint256 ratio = _amount.bdiv(
-      PCStorage.load().totalSupply.badd(LibFees.calcOutstandingAnnualFee())
-    );
+    uint256 ratio =
+      _amount.bdiv(PCStorage.load().totalSupply.badd(LibFees.calcOutstandingAnnualFee()));
 
     for (uint256 i = 0; i < tokens.length; i++) {
       address t = tokens[i];

--- a/contracts/libraries/LibSafeApprove.sol
+++ b/contracts/libraries/LibSafeApprove.sol
@@ -3,20 +3,24 @@ pragma solidity 0.6.4;
 import "../interfaces/IERC20.sol";
 
 library LibSafeApprove {
-    function safeApprove(IERC20 _token, address _spender, uint256 _amount) internal {
-        uint256 currentAllowance = _token.allowance(address(this), _spender);
+  function safeApprove(
+    IERC20 _token,
+    address _spender,
+    uint256 _amount
+  ) internal {
+    uint256 currentAllowance = _token.allowance(address(this), _spender);
 
-        // Do nothing if allowance is already set to this value
-        if(currentAllowance == _amount) {
-            return;
-        }
-
-        // If approval is not zero reset it to zero first
-        if(currentAllowance != 0) {
-            _token.approve(_spender, 0);
-        }
-
-        // do the actual approval
-        _token.approve(_spender, _amount);
+    // Do nothing if allowance is already set to this value
+    if (currentAllowance == _amount) {
+      return;
     }
+
+    // If approval is not zero reset it to zero first
+    if (currentAllowance != 0) {
+      _token.approve(_spender, 0);
+    }
+
+    // do the actual approval
+    _token.approve(_spender, _amount);
+  }
 }

--- a/contracts/libraries/LibWeights.sol
+++ b/contracts/libraries/LibWeights.sol
@@ -151,7 +151,7 @@ library LibWeights {
       s.bPool.rebind(tokens[i], s.bPool.getBalance(tokens[i]), newWeight);
     }
 
-    if(minBetweenEndBlockAndThisBlock == ws.endBlock) {
+    if (minBetweenEndBlockAndThisBlock == ws.endBlock) {
       // All the weights are adjusted, adjustment finished.
 
       // save gas option: set this to max number instead of 0

--- a/contracts/smart-pools/PV2SmartPool.sol
+++ b/contracts/smart-pools/PV2SmartPool.sol
@@ -454,9 +454,12 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Set the circuit breaker address. Can only be called by the controller
     @param _newCircuitBreaker Address of the new circuit breaker
   */
-  function setCircuitBreaker(
-    address _newCircuitBreaker
-  ) external override onlyController noReentry {
+  function setCircuitBreaker(address _newCircuitBreaker)
+    external
+    override
+    onlyController
+    noReentry
+  {
     emit CircuitBreakerChanged(P2Storage.load().circuitBreaker, _newCircuitBreaker);
     P2Storage.load().circuitBreaker = _newCircuitBreaker;
   }
@@ -568,8 +571,8 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     */
   function calcTokensForAmount(uint256 _amount)
     external
-    override
     view
+    override
     returns (address[] memory tokens, uint256[] memory amounts)
   {
     return LibPoolMath.calcTokensForAmount(_amount);
@@ -583,8 +586,8 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
   */
   function calcPoolOutGivenSingleIn(address _token, uint256 _amount)
     external
-    override
     view
+    override
     returns (uint256)
   {
     return LibPoolMath.calcPoolOutGivenSingleIn(_token, _amount);
@@ -598,8 +601,8 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
   */
   function calcSingleInGivenPoolOut(address _token, uint256 _amount)
     external
-    override
     view
+    override
     returns (uint256)
   {
     return LibPoolMath.calcSingleInGivenPoolOut(_token, _amount);
@@ -613,8 +616,8 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
   */
   function calcSingleOutGivenPoolIn(address _token, uint256 _amount)
     external
-    override
     view
+    override
     returns (uint256)
   {
     return LibPoolMath.calcSingleOutGivenPoolIn(_token, _amount);
@@ -628,8 +631,8 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
   */
   function calcPoolInGivenSingleOut(address _token, uint256 _amount)
     external
-    override
     view
+    override
     returns (uint256)
   {
     return LibPoolMath.calcPoolInGivenSingleOut(_token, _amount);
@@ -639,7 +642,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the current tokens in the smart pool
     @return Addresses of the tokens in the smart pool
   */
-  function getTokens() external override view returns (address[] memory) {
+  function getTokens() external view override returns (address[] memory) {
     return PBStorage.load().bPool.getCurrentTokens();
   }
 
@@ -647,7 +650,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the address of the controller
     @return The address of the pool
   */
-  function getController() external override view returns (address) {
+  function getController() external view override returns (address) {
     return PBStorage.load().controller;
   }
 
@@ -655,7 +658,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the address of the public swap setter
     @return The public swap setter address
   */
-  function getPublicSwapSetter() external override view returns (address) {
+  function getPublicSwapSetter() external view override returns (address) {
     return PBStorage.load().publicSwapSetter;
   }
 
@@ -663,7 +666,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the address of the token binder
     @return The token binder address
   */
-  function getTokenBinder() external override view returns (address) {
+  function getTokenBinder() external view override returns (address) {
     return PBStorage.load().tokenBinder;
   }
 
@@ -671,7 +674,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the address of the circuitBreaker
     @return The address of the circuitBreaker
   */
-  function getCircuitBreaker() external override view returns (address) {
+  function getCircuitBreaker() external view override returns (address) {
     return P2Storage.load().circuitBreaker;
   }
 
@@ -679,7 +682,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get if public swapping is enabled
     @return If public swapping is enabled
   */
-  function isPublicSwap() external override view returns (bool) {
+  function isPublicSwap() external view override returns (bool) {
     return PBStorage.load().bPool.isPublicSwap();
   }
 
@@ -687,15 +690,15 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the current cap
     @return The current cap in wei
   */
-  function getCap() external override view returns (uint256) {
+  function getCap() external view override returns (uint256) {
     return PCSStorage.load().cap;
   }
 
-  function getAnnualFee() external override view returns (uint256) {
+  function getAnnualFee() external view override returns (uint256) {
     return P2Storage.load().annualFee;
   }
 
-  function getFeeRecipient() external override view returns (address) {
+  function getFeeRecipient() external view override returns (address) {
     return P2Storage.load().feeRecipient;
   }
 
@@ -703,7 +706,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the denormalized weight of a specific token in the underlying balancer pool
     @return the normalized weight of the token in uint
   */
-  function getDenormalizedWeight(address _token) external override view returns (uint256) {
+  function getDenormalizedWeight(address _token) external view override returns (uint256) {
     return PBStorage.load().bPool.getDenormalizedWeight(_token);
   }
 
@@ -711,7 +714,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get all denormalized weights
     @return weights Denormalized weights
   */
-  function getDenormalizedWeights() external override view returns (uint256[] memory weights) {
+  function getDenormalizedWeights() external view override returns (uint256[] memory weights) {
     PBStorage.StorageStruct storage s = PBStorage.load();
     address[] memory tokens = s.bPool.getCurrentTokens();
     weights = new uint256[](tokens.length);
@@ -724,7 +727,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the address of the underlying Balancer pool
     @return The address of the underlying balancer pool
   */
-  function getBPool() external override view returns (address) {
+  function getBPool() external view override returns (address) {
     return address(PBStorage.load().bPool);
   }
 
@@ -732,7 +735,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the current swap fee
     @return The current swap fee
   */
-  function getSwapFee() external override view returns (uint256) {
+  function getSwapFee() external view override returns (uint256) {
     return PBStorage.load().bPool.getSwapFee();
   }
 
@@ -740,7 +743,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get the target weights
     @return weights Target weights
   */
-  function getNewWeights() external override view returns (uint256[] memory weights) {
+  function getNewWeights() external view override returns (uint256[] memory weights) {
     return P2Storage.load().newWeights;
   }
 
@@ -748,7 +751,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get weights at start of weight adjustment
     @return weights Start weights
   */
-  function getStartWeights() external override view returns (uint256[] memory weights) {
+  function getStartWeights() external view override returns (uint256[] memory weights) {
     return P2Storage.load().startWeights;
   }
 
@@ -756,7 +759,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get start block of weight adjustment
     @return Start block
   */
-  function getStartBlock() external override view returns (uint256) {
+  function getStartBlock() external view override returns (uint256) {
     return P2Storage.load().startBlock;
   }
 
@@ -764,7 +767,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get end block of weight adjustment
     @return End block
   */
-  function getEndBlock() external override view returns (uint256) {
+  function getEndBlock() external view override returns (uint256) {
     return P2Storage.load().endBlock;
   }
 
@@ -772,7 +775,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get new token being added
     @return New token
   */
-  function getNewToken() external override view returns (P2Storage.NewToken memory) {
+  function getNewToken() external view override returns (P2Storage.NewToken memory) {
     return P2Storage.load().newToken;
   }
 
@@ -780,7 +783,7 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
     @notice Get if joining and exiting is enabled
     @return Enabled or not
   */
-  function getJoinExitEnabled() external override view returns (bool) {
+  function getJoinExitEnabled() external view override returns (bool) {
     return P2Storage.load().joinExitEnabled;
   }
 
@@ -789,14 +792,14 @@ contract PV2SmartPool is IPV2SmartPool, PCToken, ReentryProtection {
   /**
     @notice Not Supported in PieDAO implementation of Balancer Smart Pools
   */
-  function finalizeSmartPool() external override view {
+  function finalizeSmartPool() external view override {
     revert("PV2SmartPool.finalizeSmartPool: unsupported function");
   }
 
   /**
     @notice Not Supported in PieDAO implementation of Balancer Smart Pools
   */
-  function createPool(uint256 initialSupply) external override view {
+  function createPool(uint256 initialSupply) external view override {
     revert("PV2SmartPool.createPool: unsupported function");
   }
 }

--- a/contracts/test/TestLibSafeApprove.sol
+++ b/contracts/test/TestLibSafeApprove.sol
@@ -4,19 +4,19 @@ import "../libraries/LibSafeApprove.sol";
 import "../interfaces/IERC20.sol";
 
 contract TestLibSafeApprove {
-    using LibSafeApprove for IERC20;
+  using LibSafeApprove for IERC20;
 
-    function doubleApprovalUnsafe(address _token) external {
-        IERC20 token = IERC20(_token);
+  function doubleApprovalUnsafe(address _token) external {
+    IERC20 token = IERC20(_token);
 
-        token.approve(msg.sender, 1337);
-        token.approve(msg.sender, 42);
-    }
+    token.approve(msg.sender, 1337);
+    token.approve(msg.sender, 42);
+  }
 
-    function doubleApprovalSafe(address _token) external {
-        IERC20 token = IERC20(_token);
+  function doubleApprovalSafe(address _token) external {
+    IERC20 token = IERC20(_token);
 
-        token.safeApprove(msg.sender, 1337);
-        token.safeApprove(msg.sender, 42);
-    }
+    token.safeApprove(msg.sender, 1337);
+    token.safeApprove(msg.sender, 42);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ethereum-waffle": "^2.3.2",
     "ethers": "^4.0.47",
     "prettier": "^2.0.5",
-    "prettier-plugin-solidity": "^1.0.0-alpha.52",
+    "prettier-plugin-solidity": "^1.0.0-beta.1",
     "solhint": "^3.0.0",
     "solidity-coverage": "^0.7.9",
     "ts-generator": "0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -733,10 +733,17 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.5.2.tgz#4d74670ead39e4f4fdab605a393ba8ea2390a2c4"
   integrity sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==
 
-"@solidity-parser/parser@^0.6.0", "@solidity-parser/parser@^0.6.2":
+"@solidity-parser/parser@^0.6.0":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.6.2.tgz#49707fc4e06649d39d6b25bdab2e9093d372ce50"
   integrity sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA==
+
+"@solidity-parser/parser@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.9.1.tgz#c63aaca2a07f2994d85b43afdbf90b454b62e16e"
+  integrity sha512-ewNo+ZEQX8mFUOlTK6+0IYvM++6+iEeRBIBg4Mh8ghgRX72bkXJh6AWLWe/SG5+3WPdDL84MSsAlrvWFsGRdFw==
+  dependencies:
+    antlr4 "^4.8.0"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -1129,6 +1136,11 @@ antlr4@4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
   integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
+
+antlr4@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.8.0.tgz#f938ec171be7fc2855cd3a533e87647185b32b6a"
+  integrity sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg==
 
 any-promise@1.3.0:
   version "1.3.0"
@@ -3186,13 +3198,6 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima-extract-comments@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz#0dacab567a5900240de6d344cf18c33617becbc9"
-  integrity sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==
-  dependencies:
-    esprima "^4.0.0"
-
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -3874,14 +3879,6 @@ external-editor@^3.0.3:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
-
-extract-comments@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/extract-comments/-/extract-comments-1.1.0.tgz#b90bca033a056bd69b8ba1c6b6b120fc2ee95c18"
-  integrity sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==
-  dependencies:
-    esprima-extract-comments "^1.1.0"
-    parse-code-context "^1.0.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -6178,11 +6175,6 @@ parse-cache-control@^1.0.1:
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
   integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
 
-parse-code-context@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/parse-code-context/-/parse-code-context-1.0.0.tgz#718c295c593d0d19a37f898473268cc75e98de1e"
-  integrity sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==
-
 parse-headers@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.3.tgz#5e8e7512383d140ba02f0c7aa9f49b4399c92515"
@@ -6319,18 +6311,18 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier-plugin-solidity@^1.0.0-alpha.52:
-  version "1.0.0-alpha.54"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.54.tgz#c3cf56c7964b31a26c159d6226654816e4320902"
-  integrity sha512-wPTbvPtyGopKjLxMsXqlmWS/cHnT1CNeJqm1ix7q+HkJlQkXNkXDdMZk758l8SpaFm64+eWYlhj2CzUJdULj+g==
+prettier-plugin-solidity@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.1.tgz#4efff3ea4ba449e5c88f4ada6aca889c676547a6"
+  integrity sha512-kfPkR+UscT/Cw+2O8RSh6gCnIY4qsJJtuE4xZpIq42EyNyTLBabDwjH1QocXHwmlgL6QffydDge76ERlyJRaAA==
   dependencies:
-    "@solidity-parser/parser" "^0.6.2"
+    "@solidity-parser/parser" "^0.9.1"
     dir-to-object "^2.0.0"
     emoji-regex "^9.0.0"
     escape-string-regexp "^4.0.0"
-    extract-comments "^1.1.0"
     prettier "^2.0.5"
     semver "^7.3.2"
+    solidity-comments-extractor "^0.0.4"
     string-width "^4.2.0"
 
 prettier@^1.14.2, prettier@^1.14.3:
@@ -7217,6 +7209,11 @@ solhint@^3.0.0:
     semver "^6.3.0"
   optionalDependencies:
     prettier "^1.14.3"
+
+solidity-comments-extractor@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.4.tgz#ce420aef23641ffd0131c7d80ba85b6e1e42147e"
+  integrity sha512-58glBODwXIKMaQ7rfcJOrWtFQMMOK28tJ0/LcB5Xhu7WtAxk4UX2fpgKPuaL41XjMp/y0gAa1MTLqk018wuSzA==
 
 solidity-coverage@^0.7.9:
   version "0.7.9"


### PR DESCRIPTION
##### Description

Upgrade prettier solidity to its latest version

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Test coverage hasn't decreased

##### Testing

It only changes the format of the code

---

Hi everyone! We released a beta version of prettier-solidity this week, so I'm checking which projects are using it to see if this version works fine.

I upgraded the dependency to this latest version and also re-run prettier on your contracts. These caused a lot of changes, but I think it shouldn't be hard to review them with the whitespace diff disabled.

Also: I'm compiling a list of projects that use prettier solidity, would it be ok with you if I include PieDAO on that list?

Thank you!